### PR TITLE
Fix typos in source

### DIFF
--- a/ldacdec.h
+++ b/ldacdec.h
@@ -9,7 +9,7 @@
 
 #define container_of( ptr, type, member ) ({                \
         const typeof( ((type*)0)->member ) *__mptr = (ptr); \
-        (type *)((char*)__ptr - offsetof(type, memeber));   \
+        (type *)((char*)__ptr - offsetof(type, member));   \
         })
 
 #define min( a, b )             \

--- a/ldacenc.c
+++ b/ldacenc.c
@@ -159,7 +159,7 @@ void do_ldac_resample(SNDFILE *in, SF_INFO *info, int new_sample_rate, FILE *out
         }
 		if ((error = src_process (src_state, &src_data)))
 		{	
-            printf ("src_process faild : %s\n", src_strerror (error)) ;
+            printf ("src_process failed : %s\n", src_strerror (error)) ;
 			break;
 		}
 


### PR DESCRIPTION
2 separate commits that fix typos. One of them fixes a potential bug. The other is cosmetic and user-facing.